### PR TITLE
Makefile Update for mkdocs gh-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ doc_build:
 	# Build the documentation using MkDocs
 	mkdocs build
 
+doc_deploy:
+	# Deploy the documentation to GitHub Pages
+	mkdocs gh-deploy
+
 doc_open: doc_build
 	# Open the documentation in the default web browser
 	open site/index.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "numpy",
   "matplotlib",
   "pyyaml",
+  "pytest",
   "mkdocs",
   "mkdocs-material",
   "mkdocstrings[python]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,15 @@ dependencies = [
   "numpy",
   "matplotlib",
   "pyyaml",
-  "pytest",
+
+  # Needed for testing
+  "pytest", 
+
+  # Needed for documentation
   "mkdocs",
   "mkdocs-material",
   "mkdocstrings[python]",
+  "markdown-exec", # markdown-exec - Needed by mkdocs build
 ]
 requires-python = ">=3.8"
 


### PR DESCRIPTION
- Added doc_deploy target in the Makefile
  - to deploy the built doc on gh-pages branch
- updated the pyproject.toml to support mkdocs dependancies
