### PR TITLE
Handle python 3.11 as the minimal python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The Graphic Server Protocol (GSP) defines the protocol used between a visualizat
 
 ## How to install the project
 
+Note that GSP requires Python 3.13 or higher.
+
 Potentially create a virtual environment
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Graphic Server Protocol (GSP) defines the protocol used between a visualizat
 
 ## How to install the project
 
-Note that GSP requires Python 3.13 or higher.
+Note that GSP requires Python 3.11 or higher.
 
 Potentially create a virtual environment
 

--- a/gsp/__init__.py
+++ b/gsp/__init__.py
@@ -13,7 +13,7 @@ from . import transform
 # minimal version of python is 3.11 - check it is respected. if not, then exit with an error message
 import sys
 if sys.version_info < (3, 11):
-    print("Python 3.13 or higher is required.")
+    print("Python 3.11 or higher is required.")
     sys.exit(1)
 
 @io.register("str", "memoryview")

--- a/gsp/__init__.py
+++ b/gsp/__init__.py
@@ -10,9 +10,9 @@ from . import core
 from . import visual
 from . import transform
 
-# minimal version of python is 3.13 - check it is respected. if not, then exit with an error message
+# minimal version of python is 3.11 - check it is respected. if not, then exit with an error message
 import sys
-if sys.version_info < (3, 13):
+if sys.version_info < (3, 11):
     print("Python 3.13 or higher is required.")
     sys.exit(1)
 

--- a/gsp/__init__.py
+++ b/gsp/__init__.py
@@ -10,6 +10,12 @@ from . import core
 from . import visual
 from . import transform
 
+# minimal version of python is 3.13 - check it is respected. if not, then exit with an error message
+import sys
+if sys.version_info < (3, 13):
+    print("Python 3.13 or higher is required.")
+    sys.exit(1)
+
 @io.register("str", "memoryview")
 def str_to_memoryview(obj):
     return memoryview(bytes(obj))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "mkdocstrings[python]",
   "markdown-exec", # markdown-exec - Needed by mkdocs build
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 
 authors = [
   {name = "Nicolas P. Rougier", email = "nicolas.rougier@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "mkdocstrings[python]",
   "markdown-exec", # markdown-exec - Needed by mkdocs build
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.13"
 
 authors = [
   {name = "Nicolas P. Rougier", email = "nicolas.rougier@gmail.com"}


### PR DESCRIPTION
It modifies the README.md and add a check in `__init__.py`

If gsp is imported on a python less than 3.13, the message `Python 3.13 or higher is required.` is displayed

UPDATE: changed it to 3.11 after discussion