### PR TITLE
Remove "jsonrpc" version and replace it by "gsp_version"

### DIFF
--- a/gsp/io/json.py
+++ b/gsp/io/json.py
@@ -64,7 +64,7 @@ def dump(queue=None, filename=None):
     commands = []
     for command in queue.commands:
         commands.append(dump_command(command, stream=None))
-    payload = { "jsonrpc": "2.0", "commands" : commands }
+    payload = { "gsp_version": "1.0", "commands" : commands }
 
     if filename is None:
         return json.dumps(payload, indent=2, default=default)


### PR DESCRIPTION
gsp.io.json is producing json file with the mention `"jsonrpc": "2.0"` but we are producing json not jsonrpc. 

- This pull request remove the "jsonrpc" to avoid confusion
- it adds "gsp_version" : "1.0" to help keeping track of the json format we use
- based on #11