### PR TITLE
Adding a .render for visuals where it was missing

### DIFF
--- a/examples/lidar-point-cloud.py
+++ b/examples/lidar-point-cloud.py
@@ -150,6 +150,7 @@ viewport = core.Viewport(canvas, x=0, y=0, width=canvas_width, height=canvas_hei
 
 # Create a Pixels visual
 pixels = visual.Pixels(positions=point_positions, colors=point_colors)
+pixels.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [pixels])

--- a/examples/markers-2d.py
+++ b/examples/markers-2d.py
@@ -35,6 +35,7 @@ sizes = glm.float(n)
 sizes[...] = np.linspace(0.05, 12.0,n)**2
 types = core.Marker.star
 markers = visual.Markers(P, types, sizes, None, angles, black, white, 0.5)
+markers.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [markers])

--- a/examples/markers-3d.py
+++ b/examples/markers-3d.py
@@ -39,6 +39,7 @@ markers = visual.Markers(P,
                          fill_colors = colormap(depth),
                          line_colors = white,
                          line_widths = 0.0)
+markers.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [markers])

--- a/examples/paths-2d.py
+++ b/examples/paths-2d.py
@@ -40,6 +40,7 @@ paths = visual.Paths(P, I.tolist(),
                      line_styles = gsp.core.LineStyle.solid,
                      line_joins = gsp.core.LineJoin.miter,
                      line_caps = gsp.core.LineCap.round)
+paths.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [paths])

--- a/examples/paths-3d.py
+++ b/examples/paths-3d.py
@@ -40,6 +40,7 @@ paths = visual.Paths(P, I,
                      line_styles = gsp.core.LineStyle.solid,
                      line_joins = gsp.core.LineJoin.round,
                      line_caps = gsp.core.LineCap.round)
+paths.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [paths])

--- a/examples/paths-regular-2d.py
+++ b/examples/paths-regular-2d.py
@@ -44,6 +44,7 @@ paths = visual.Paths(P, I,
                      line_styles = gsp.core.LineStyle.solid,
                      line_joins = gsp.core.LineJoin.round,
                      line_caps = gsp.core.LineCap.round)
+paths.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [paths])

--- a/examples/pixels-2d.py
+++ b/examples/pixels-2d.py
@@ -24,6 +24,7 @@ viewport = core.Viewport(canvas, 0, 0, 512, 512, [1,1,1,1])
 n = 250_000
 P = glm.to_vec3(np.random.uniform(-1, +1, (n,2)))
 pixels = visual.Pixels(P, colors=[0,0,0,1])
+pixels.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [pixels])

--- a/examples/pixels-3d.py
+++ b/examples/pixels-3d.py
@@ -24,6 +24,7 @@ viewport = core.Viewport(canvas, 0, 0, 512, 512, [1,1,1,1])
 n = 250_000
 P = glm.as_vec3(np.random.uniform(-1, +1, (n,3)))
 pixels = visual.Pixels(P, colors=[0,0,0,1])
+pixels.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [pixels])

--- a/examples/pixels-colormap.py
+++ b/examples/pixels-colormap.py
@@ -27,6 +27,7 @@ n = 500_000
 P = glm.as_vec3(np.random.uniform(-1, +1, (n,3)))
 C = colormap(depth)
 pixels = visual.Pixels(P, C)
+pixels.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [pixels])

--- a/examples/pixels-colors.py
+++ b/examples/pixels-colors.py
@@ -25,6 +25,7 @@ n = 250_000
 P = glm.as_vec3(np.random.uniform(-1, +1, (n,3)))
 C = (P+1)/2
 pixels = visual.Pixels(P, C)
+pixels.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [pixels])

--- a/examples/points-2d.py
+++ b/examples/points-2d.py
@@ -32,6 +32,7 @@ sizes = glm.float(n)
 sizes[...] = np.linspace(0.05, 12.0,n)**2
 
 points = visual.Points(P, sizes, black, black, 0.0)
+points.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [points])

--- a/examples/points-3d.py
+++ b/examples/points-3d.py
@@ -35,6 +35,7 @@ linewidths = glm.float(n)
 linewidths[...] = _linewidths
 
 points = visual.Points(positions, sizes, gsp.grey, gsp.white, linewidths)
+points.render(viewport)
 
 def update(viewport, model, view, proj, camera):
     sizes[...] =  1/(camera.zoom**2) * _sizes

--- a/examples/points-colormap.py
+++ b/examples/points-colormap.py
@@ -29,6 +29,7 @@ positions = glm.vec3(10_000)
 positions[...] = np.random.uniform(-1, +1, (len(positions),3))
 fill_colors = colormap(depth)
 points = visual.Points(positions, 25.0, fill_colors, gsp.black, 0.25)
+points.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [points])

--- a/examples/polygons-2d.py
+++ b/examples/polygons-2d.py
@@ -41,6 +41,7 @@ polys = visual.Polygons(P, I,
                         line_widths = 2.0,
                         line_styles = gsp.core.LineStyle.solid,
                         line_joins = gsp.core.LineJoin.round)
+polys.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [polys])

--- a/examples/segments-2d.py
+++ b/examples/segments-2d.py
@@ -32,6 +32,7 @@ segments = visual.Segments(P,
                            line_caps = gsp.core.LineCap.round,
                            line_colors = black,
                            line_widths=line_widths)
+segments.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [segments])

--- a/examples/segments-fixed-size.py
+++ b/examples/segments-fixed-size.py
@@ -31,6 +31,7 @@ S1 = visual.Segments(P,
                      line_caps = gsp.core.LineCap.round,
                      line_colors = black,
                      line_widths=0.5)
+S1.render(viewport)
 
 P = glm.vec3((4,2))
 P[0] = (-128, -128, 0), (-128,  128, 0)
@@ -46,7 +47,7 @@ S2 = visual.Segments(P * pixel,
                      line_caps = gsp.core.LineCap.round,
                      line_colors = black,
                      line_widths=0.5)
-
+S2.render(viewport)
 
 # Show or save the result
 render(canvas, [viewport], [S1, S2])


### PR DESCRIPTION
A bunch of examples didn't have the `.render(viewport)`. This PR adds it. 


To call `.render()` is required
- to init `.transform` 
- to init matplotlib when using matplotlib