### PR TITLE
Removing gsp.use() and change CommandQueue.run() API

### DIFF
--- a/examples/common/launcher.py
+++ b/examples/common/launcher.py
@@ -84,22 +84,18 @@ class _ExampleLauncher:
                 # reset objects - TODO make it cleaner - call a function e.g. .clear() ?
                 gsp.Object.objects = {}
 
-                # gsp.Object.clear()
-
                 # load commands from file
                 command_queue = gsp.io.json.load(commands_filename)
 
+                # dump commands
                 for command in command_queue:
                     gsp.log.info("%s" % command)
 
-                # KEY: REQUIRED FOR THE GLOBALS - Super dirty!!!
-                # gsp.use("matplotlib")
+                # execute commands using gsp_matplotlib as backend
+                command_queue.run(gsp_matplotlib)
 
-                # TODO send matplotlib as namespace in command_queue.run
-                command_queue.run(globals(), locals())
-
+                # Display the result using matplotlib (just to debug)
                 import matplotlib.pyplot as plt
-
                 plt.show(block=True)
         elif args.command == "matplotlib_image":
             import matplotlib.pyplot as plt

--- a/examples/io_saveload.py
+++ b/examples/io_saveload.py
@@ -50,6 +50,9 @@ class Foo(Object):
         return f"Foo(id={self.id}, value={self.value})"
 
 
+# Create a fake module to simulate a backend. typically it is `gsp` or `gsp_matplotlib`
+backend_module = type('backend_module', (), {'Foo': Foo})()
+
 print(f"—————{__doc__}—————\n")
 
 # Client
@@ -65,7 +68,7 @@ print("2. Commands execution")
 Object.objects = {}
 for command in queue:
     command.dump()
-queue.run(globals(), locals())
+queue.run(backend_module)
 print(Object.objects[1])
 
 print()
@@ -80,6 +83,6 @@ queue = json.load(json_path)
 for command in queue:
     log.info("%s" % command)
 
-queue.run(globals(), locals())
+queue.run(backend_module)
 print(Object.objects[1])
 print()

--- a/gsp/__init__.py
+++ b/gsp/__init__.py
@@ -54,33 +54,6 @@ black = [0.0, 0.0, 0.0, 1.0]
 grey  = [0.5, 0.5, 0.5, 1.0]
 white = [1.0, 1.0, 1.0, 1.0]
 
-def use(backend):
-    """
-    Specify a backend to use by importing core, transform and
-    visual modules into global namespace.
-    """
-
-    import inspect
-    import numpy as np
-    from . import transform
-
-    if backend == "matplotlib":
-        from . import transform
-        from gsp_matplotlib import glm
-        from gsp_matplotlib import core
-        from gsp_matplotlib import visual
-        import matplotlib.pyplot as plt
-        inspect.stack()[1][0].f_globals["glm"] = glm
-        inspect.stack()[1][0].f_globals["plt"] = plt
-    else:
-        from . import core
-
-    inspect.stack()[1][0].f_globals["np"] = np
-    inspect.stack()[1][0].f_globals["core"] = core
-    inspect.stack()[1][0].f_globals["transform"] = transform
-    inspect.stack()[1][0].f_globals["visual"] = visual
-
-
 def save(filename, format=None):
     """
     Save default command stack into a file. If format is not

--- a/gsp/io/command.py
+++ b/gsp/io/command.py
@@ -129,7 +129,7 @@ class CommandQueue(metaclass = NamedSingleton):
         return self.commands[index]
 
 
-    def run(self,  globals=None, locals=None):
+    def run(self, backend_module: types.ModuleType):
         """
         Execute all commands in the queue, with the provided
         globals and locals dictionary that must contain claases and
@@ -150,7 +150,7 @@ class CommandQueue(metaclass = NamedSingleton):
         readonly = self.readonly
         self.readonly = True
         for command in self.commands:
-            command.execute(globals, locals)
+            command.execute(backend_module)
         self.readonly = readonly
 
 
@@ -406,7 +406,7 @@ class Command:
                       % (key, type(value).__name__))
 
 
-    def execute(self, globals=None, locals=None):
+    def execute(self, backend_module: types.ModuleType):
         """ Execute the command. """
 
         parameters = self.parameters.copy()
@@ -443,7 +443,8 @@ class Command:
             Object.objects[oid] = object
             return object
         elif self.methodname == "__init__":
-            func = eval(self.classname, globals, locals)
+            source = f"backend_module.{self.classname}"
+            func = eval(source, None, {'backend_module': backend_module})
             object = func(**parameters)
             object.id = oid
             Object.objects[oid] = object


### PR DESCRIPTION
- Pull request based on #31

## Changes
- remove `gsp.use()` to avoid globals
- changed commandQueue.run API to remove the dependancy on those globals

## old API
```python
commandQueue.run(globals(), locals())
```

## new API
```python
commandQueue.run(gsp_matplotlib)
```